### PR TITLE
Allow Xvs to start with zero

### DIFF
--- a/src/Keys.ts
+++ b/src/Keys.ts
@@ -131,7 +131,7 @@ export class Xper extends Key {
 
 export class Xvs extends Key {
 	constructor(value: string) {
-		super('x-vs', value, /^[1-9][0-9]{0,9}$/);
+		super('x-vs', value, /^[0-9]{0,10}$/);
 	}
 }
 


### PR DESCRIPTION
As stated by Moneta bank:

> The variable symbol is optional data on the payment order, it consists of numbers and its maximum length is 10 characters. It is necessary to understand that even the zero before the number is very important. The composition of the variable symbol has no binding rules.

- https://www.moneta.cz/slovnik-pojmu/detail/co-je-variabilni-symbol

This pull request allows the variable symbol to start with a zero.

**Please note that it is very common to set variable symbol as your birth/tax number, which can start with a zero.**