### PR TITLE
fix: types exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,18 @@
 	"main": "./dist/spayd.umd.min.js",
 	"types": "./dist/types/index.d.ts",
 	"exports": {
-		".": "./dist/spayd.umd.min.js",
-		"./esm": "./dist/spayd.esm.js",
-		"./cjs": "./dist/spayd.cjs.js"
+		".": {
+			"default": "./dist/spayd.umd.min.js",
+			"types": "./dist/types/index.d.ts"
+		},
+		"./esm": {
+			"default": "./dist/spayd.esm.js",
+			"types": "./dist/types/index.d.ts"
+		},
+		"./cjs": {
+			"default": "./dist/spayd.cjs.js",
+			"types": "./dist/types/index.d.ts"
+		}
 	},
 	"typesVersions": {
 		"*": {


### PR DESCRIPTION
Fixes this error:

```
Could not find a declaration file for module 'spayd/esm'. '[REDACTED]/node_modules/.bun/spayd@3.0.4/node_modules/spayd/dist/spayd.esm.js' implicitly has an 'any' type.
  There are types at '[REDACTED]/node_modules/spayd/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports".
  The 'spayd' library may need to update its package.json or typings. ts(7016)
```